### PR TITLE
Zusätzlicher EP URL_PROFILE_QUERY für komplexere Manipulation des Queries

### DIFF
--- a/lib/Url/Profile.php
+++ b/lib/Url/Profile.php
@@ -654,7 +654,10 @@ class Profile
                 );
             }
         }
-        return $query;
+        
+        return \rex_extension::registerPoint(new \rex_extension_point('URL_PROFILE_QUERY', $query, [
+            'profile' => $this
+        ]));
     }
 
     /**


### PR DESCRIPTION
Über diesen EP ließen sich komplexere Abfragen realisieren, als sie mit URL_PROFILE_RESTRICTION möglich sind. Es werden z.B. Abfragen weiterer Tabellen möglich. Ich verwalte z.B. Sprachversionen eines Datensatzes in Inline-Relationen. Das bedeutet, der Status wird im Haupt-Datensatz, die URL-Daten in den Inline-Datensätzen verwaltet. Über den EP kann ich die Daten zusammenführen.